### PR TITLE
fix bug that wrong worker being removed when one exit

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -169,18 +169,23 @@ cluster.fork = function(env) {
       });
     }
   }
-  
+
+  function ondisconnect() {
+    var index = workers.indexOf(obj);
+    if (index >= 0) {
+      workers.splice(index, 1);
+    }
+  }
+
   function onexit() {
-    workers.splice(workers.indexOf(obj), 1);
     worker.removeListener('online', obj.ononline);
     worker.removeListener('message', obj.onmessage);
-    return false;
   }
 
   worker.on('online', ononline);
   worker.on('message', onmessage);
+  worker.on('disconnect', ondisconnect);
   worker.on('exit', onexit);
-  worker.on('disconnect', onexit);
 
   return worker;
 };


### PR DESCRIPTION
When one worker exits, `onexit` would be called two times on 'disconnect' and 'exit' events.
And `workers.splice(workers.indexOf(obj), 1);` becomes `workers.splice(-1,1);` at the second time which removes one more worker than necessary.