### PR TITLE
fix bug that wrong worker being removed when one exit

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -171,7 +171,10 @@ cluster.fork = function(env) {
   }
   
   function onexit() {
-    workers.splice(workers.indexOf(obj), 1);
+    var index = workers.indexOf(obj);
+    if (index >= 0) {
+      workers.splice(index, 1);
+    }
     worker.removeListener('online', obj.ononline);
     worker.removeListener('message', obj.onmessage);
     return false;


### PR DESCRIPTION
When one worker exits, `onexit` would be called two times on 'disconnect' and 'exit' events.
And `workers.splice(workers.indexOf(obj), 1);` becomes `workers.splice(-1,1);` at the second time which removes one more worker than necessary.
Tweaked the codes in #6 .